### PR TITLE
Fix query not found when the lang is different from filetype

### DIFF
--- a/lua/tsht.lua
+++ b/lua/tsht.lua
@@ -49,7 +49,8 @@ function M.nodes()
   api.nvim_buf_clear_namespace(0, ns, 0, -1)
   local ts = vim.treesitter
   local get_query = require('vim.treesitter.query').get_query
-  local query = get_query(vim.bo.filetype, 'locals')
+  local get_parser = require("vim.treesitter").get_parser
+  local query = get_query(get_parser(0)._lang, 'locals')
   if not query then
     print('No locals query for language', vim.bo.filetype)
     return


### PR DESCRIPTION
Thanks for the awesome plugin! But I sometimes feel frustrated when I work on jsx or tsx files, the plugin doesn't work. The reason is that the 'filetype' of jsx in vim is `javascriptreact`, while in the treesitter query that is `jsx`, causing that the plugin couldn't find the local queries using the filetype `javascriptreact`. 

So I made a simple patch here, currently works for me. Hope it will help.