### PR TITLE
fix: restore highlight groups when changing colorscheme

### DIFF
--- a/plugin/tsht.vim
+++ b/plugin/tsht.vim
@@ -2,5 +2,11 @@ if exists('g:nvim_ts_hint_textobject')
   finish
 endif
 let g:nvim_ts_hint_textobject = 1
-hi! def TSNodeUnmatched guifg=#666666 ctermfg=242
-hi! def TSNodeKey guifg=#ff007c gui=bold ctermfg=198 cterm=bold
+
+function s:setup_highlights()
+  hi! def TSNodeUnmatched guifg=#666666 ctermfg=242
+  hi! def TSNodeKey guifg=#ff007c gui=bold ctermfg=198 cterm=bold
+endfunction
+
+call s:setup_highlights()
+autocmd ColorScheme * call s:setup_highlights()


### PR DESCRIPTION
After colorscheme was changed letters become of the same color of normal text

This PR restores highlight groups after changing colorscheme