### PR TITLE
Resolve parser lang when different from filetype

### DIFF
--- a/lua/tsht.lua
+++ b/lua/tsht.lua
@@ -47,15 +47,15 @@ end
 
 function M.nodes()
   api.nvim_buf_clear_namespace(0, ns, 0, -1)
-  local ts = vim.treesitter
   local get_query = require('vim.treesitter.query').get_query
-  local get_parser = require("vim.treesitter").get_parser
-  local query = get_query(get_parser(0)._lang, 'locals')
+  local parsers = require('nvim-treesitter.parsers')
+  local lang = parsers.get_buf_lang(0)
+  local query = get_query(lang, 'locals')
   if not query then
-    print('No locals query for language', vim.bo.filetype)
+    print('No locals query for language', lang)
     return
   end
-  local parser = ts.get_parser(0)
+  local parser = parsers.get_parser(0)
   local trees = parser:parse()
   local root = trees[1]:root()
   local lnum, col = unpack(api.nvim_win_get_cursor(0))


### PR DESCRIPTION
Use nvim-treesitter API to resolve the parser language when it is different than the buffer's `filetype`.

This happens for `tsx` files whose `filetype` is `typescriptreact` but the Treesitter parser language is `tsx`. The mapping of filetypes and parser languages is [stored in nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/32e364ea3c99aafcce2ce735fe091618f623d889/lua/nvim-treesitter/parsers.lua#L4-L21).

PR #4 fixed that problem before. It seems that the solution stopped working over time.

Closes #17 

## Before (on `master`)


https://user-images.githubusercontent.com/889383/173181320-7471c0ca-3580-4f3c-9794-6a09d90acb45.mp4



```
E5108: Error executing lua ...local/share/nvim/runtime/lua/vim/treesitter/language.lua:25: no parser for
 'typescriptreact' language, see :help treesitter-parsers
stack traceback:
        [C]: in function 'error'
        ...local/share/nvim/runtime/lua/vim/treesitter/language.lua:25: in function 'require_language'
        /usr/local/share/nvim/runtime/lua/vim/treesitter.lua:39: in function '_create_parser'
        /usr/local/share/nvim/runtime/lua/vim/treesitter.lua:98: in function 'get_parser'
        ...nvim/site/pack/packer/start/nvim-treehopper/lua/tsht.lua:53: in function 'nodes'
        [string ":lua"]:1: in main chunk
Press ENTER or type command to continue
```

## After


https://user-images.githubusercontent.com/889383/173181326-4f90d48e-8af5-4850-8151-485a2c0b0a17.mp4

