### PR TITLE
Simplify getting node at cursor position

### DIFF
--- a/lua/tsht.lua
+++ b/lua/tsht.lua
@@ -47,15 +47,15 @@ end
 
 function M.nodes()
   api.nvim_buf_clear_namespace(0, ns, 0, -1)
-  local ts = vim.treesitter
   local get_query = require('vim.treesitter.query').get_query
-  local get_parser = require("vim.treesitter").get_parser
-  local query = get_query(get_parser(0)._lang, 'locals')
+  local parsers = require('nvim-treesitter.parsers')
+  local lang = parsers.get_buf_lang(0)
+  local query = get_query(lang, 'locals')
   if not query then
-    print('No locals query for language', vim.bo.filetype)
+    print('No locals query for language', lang)
     return
   end
-  local parser = ts.get_parser(0)
+  local parser = parsers.get_parser(0)
   local trees = parser:parse()
   local root = trees[1]:root()
   local lnum, col = unpack(api.nvim_win_get_cursor(0))

--- a/lua/tsht.lua
+++ b/lua/tsht.lua
@@ -47,20 +47,14 @@ end
 
 function M.nodes()
   api.nvim_buf_clear_namespace(0, ns, 0, -1)
-  local get_query = require('vim.treesitter.query').get_query
   local parsers = require('nvim-treesitter.parsers')
   local lang = parsers.get_buf_lang(0)
-  local query = get_query(lang, 'locals')
-  if not query then
+  local has_locals = require('nvim-treesitter.query').has_query_files(lang, 'locals')
+  if not has_locals then
     print('No locals query for language', lang)
     return
   end
-  local parser = parsers.get_parser(0)
-  local trees = parser:parse()
-  local root = trees[1]:root()
-  local lnum, col = unpack(api.nvim_win_get_cursor(0))
-  lnum = lnum - 1
-  local cursor_node = root:descendant_for_range(lnum, col, lnum, col)
+  local cursor_node = require('nvim-treesitter.ts_utils').get_node_at_cursor(0)
   local iter = keys_iter()
   local hints = {}
   local win_info = vim.fn.getwininfo(api.nvim_get_current_win())[1]


### PR DESCRIPTION
This PR uses some of `nvim-treesitter`'s APIs to reduce the complexity of getting the node at the cursor position. It reduces the complexity of the plugin by using higher-level operations.

This PR builds on top of #14 which should be merged first. Then, this PR will have only 1 commit, which should be merged later (after a rebase). I wanted to be granular with the PRs so you can decide to ignore this one (as it is purely a refactor) and focus only on merging #14 (which is a bugfix).

When reviewing, review only the 2nd commit in this PR (_Simplify getting node at cursor_).