### PR TITLE
wrap autocmd for highlight application in a augroup

### DIFF
--- a/plugin/tsht.vim
+++ b/plugin/tsht.vim
@@ -9,4 +9,7 @@ function s:setup_highlights()
 endfunction
 
 call s:setup_highlights()
-autocmd ColorScheme * call s:setup_highlights()
+augroup TreehopperHighlight
+    autocmd!
+    autocmd ColorScheme * call s:setup_highlights()
+augroup end


### PR DESCRIPTION
As far as I can tell, this makes no difference to the default behavior. But this allows setting custom highlights that persist through a colorscheme change by deleting or overwriting the augroup:

```lua
local function set_hl()
  vim.api.nvim_set_hl(0, 'TSNodeKey', { reverse = true })
  vim.api.nvim_set_hl(0, 'TSNodeUnmatched', { link = "Comment" })
end

vim.api.nvim_create_autocmd('ColorScheme', {
  group = vim.api.nvim_create_augroup('TreehopperHighlight', { clear = true }),
  callback = set_hl
})
```

BTW: I think above highlights make more sense as the current default, as it will look passable on any colorscheme. If you're willing to consider changing over from the current hard coded values I can create a PR.