### PR TITLE
change default highlights to colorscheme-friendly links

### DIFF
--- a/plugin/tsht.vim
+++ b/plugin/tsht.vim
@@ -4,8 +4,8 @@ endif
 let g:nvim_ts_hint_textobject = 1
 
 function s:setup_highlights()
-  hi! def TSNodeUnmatched guifg=#666666 ctermfg=242
-  hi! def TSNodeKey guifg=#ff007c gui=bold ctermfg=198 cterm=bold
+  hi! link TSNodeUnmatched Comment
+  hi! def TSNodeKey gui=reverse cterm=reverse
 endfunction
 
 call s:setup_highlights()


### PR DESCRIPTION
This is the change I proposed in #25. This changes the default appearance during label selection from the hardcoded pink on gray style to a commented-out buffer with reversed color labels in them. This gives a decent and consistent look on all colorschemes I've tried.

I've also toyed with converting this file to Lua as all functions are available in the latest neovim releases, but couldn't get it to load properly (I don't know enough about plugin loading).