### PR TITLE
Allow customized highlighting for unmatched text

### DIFF
--- a/plugin/tsht.vim
+++ b/plugin/tsht.vim
@@ -4,7 +4,7 @@ endif
 let g:nvim_ts_hint_textobject = 1
 
 function s:setup_highlights()
-  hi! link TSNodeUnmatched Comment
+  hi def link TSNodeUnmatched Comment
   hi! def TSNodeKey gui=reverse cterm=reverse
 endfunction
 


### PR DESCRIPTION
This lets me have a `TSNodeUnmatched` in my colorscheme.

- It still links to `Comment` when `TSNodeUnmatched` is undefined
- It still works correctly if you switch between schemes with and without `TSNodeUnmatched` defined. 