### PR TITLE
feat: solve language with nvim-treesitter as an optional dependency

### DIFF
--- a/lua/tsht.lua
+++ b/lua/tsht.lua
@@ -99,7 +99,10 @@ end
 
 
 local function get_parser(bufnr)
-  local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+  local has_lang, lang = pcall(function()
+    return require("nvim-treesitter.parsers").ft_to_lang(vim.bo.filetype)
+  end)
+  local ok, parser = pcall(vim.treesitter.get_parser, bufnr, has_lang and lang or nil)
   local err
   if ok then
     return parser


### PR DESCRIPTION
Currently, `get_paresr` assumes filetype contain the language name.

However, this is not always the case.
For example, I use hcl language parser for tf (Terraform) file.

This PR reduces this limitation by using nvim-treesitter if available.

This is similar to #27, but `nvim-treesitter` is optional.