### PR TITLE
feat: support parser injections

### DIFF
--- a/lua/tsht.lua
+++ b/lua/tsht.lua
@@ -127,6 +127,14 @@ local function insert_parent_ranges(ranges, node)
   end
 end
 
+local function get_node(opts)
+  if vim.treesitter.get_node then
+    return vim.treesitter.get_node(opts)
+  end
+  return vim.treesitter.get_node_at_pos(
+    opts.bufnf, opts.pos[1], opts.pos[2], { ignore_injections = opts.ignore_injections }
+  )
+end
 
 local function ts_parents_from_cursor(opts)
   local injection = opts and opts.ignore_injections == false or false
@@ -137,7 +145,7 @@ local function ts_parents_from_cursor(opts)
 
   -- assume parser injection
   if injection then
-    local node = vim.treesitter.get_node_at_pos(0, lnum - 1, col, {lang = lang, ignore_injections = false})
+    local node = get_node({ bufnr = 0, pos = {lnum - 1, col}, ignore_injections = false })
     if node ~= nil then
       node_id = node:id()
       insert_parent_ranges(ranges, node)

--- a/lua/tsht.lua
+++ b/lua/tsht.lua
@@ -268,6 +268,10 @@ local function region(opts)
 end
 
 
+--- Visual selection on a node
+---
+---@param opts table|nil
+--- - ignore_injections boolean|nil defaults to true
 function M.nodes(opts)
   local run = coroutine.wrap(function()
     region(opts)
@@ -281,6 +285,7 @@ end
 ---
 ---@param opts table|nil
 --- - side "start"|"end"|nil defaults to "start"
+--- - ignore_injections boolean|nil defaults to true
 function M.move(opts)
   coroutine.wrap(function() move(opts) end)()
 end


### PR DESCRIPTION
This PR enables selections and movings on nodes respecting parser injections.
The default behavior ignores injections inheriting that of `vim.treesitter`

``` lua
:lua require('tsht').nodes({ignore_injections = false})
```

![image](https://user-images.githubusercontent.com/30277794/220144670-3a9f37f1-15a3-425e-8d8f-b152b8d36130.png)
